### PR TITLE
Run tests on setup and stop continuous testing when the buffer is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ end)
 -- %file will be replace with the test file
 require("continuous-testing").setup {
     notify = true, -- The default is false
+    run_tests_on_setup = false, -- The default is true
     framework_setup = {
         ruby = {
             test_tool = "rspec",

--- a/lua/continuous-testing/commands.lua
+++ b/lua/continuous-testing/commands.lua
@@ -64,6 +64,10 @@ local attach_on_save_autocmd = function(bufnr, cmd, pattern)
         pattern = pattern,
         callback = testing_module.test_result_handler(bufnr, cmd),
     })
+
+    vim.api.nvim_create_autocmd("BufDelete", {
+        callback = stop_continuous_testing_cmd(bufnr),
+    })
 end
 
 local attach_test = function()

--- a/lua/continuous-testing/config.lua
+++ b/lua/continuous-testing/config.lua
@@ -5,6 +5,7 @@ local config = {}
 
 local DEFAULT_CONFIG = {
     notify = false,
+    run_tests_on_setup = false,
 }
 
 local set_default_values = function()

--- a/lua/continuous-testing/languages/ruby/rspec.lua
+++ b/lua/continuous-testing/languages/ruby/rspec.lua
@@ -98,8 +98,6 @@ M.testing_dialog_message = function(bufnr, line_position)
 end
 
 M.test_result_handler = function(bufnr, cmd)
-    notify({ "Adding " .. file_util.file_name(bufnr) }, vim.log.levels.INFO)
-
     return function()
         if state(bufnr)["job"] ~= nil then
             vim.fn.jobstop(state(bufnr)["job"])


### PR DESCRIPTION
As the title says.
Two small improvements:
1. If you would accidentally close a buffer that has `ContinuousTesting` active on it, it would remain active and keep running these tests in the background whenever the event was triggered. However there is no longer a buffer to write its data to.
When reopening this file again in another buffer and trying to activate the ContinuousTesting again it would say `ContinuousTesting` is already active.
So now it will clear the autocmd on a `BufDelete` event.
2. Run tests immediately when attaching ContinuousTesting to a buffer. If this is not of your likings it can be deactivated with simple config.