### PR TITLE
Set the BufDelete event on a specific buffer instead of all buffers

### DIFF
--- a/lua/continuous-testing/commands.lua
+++ b/lua/continuous-testing/commands.lua
@@ -73,6 +73,7 @@ local attach_on_save_autocmd = function(bufnr, cmd, pattern)
 
     vim.api.nvim_create_autocmd("BufDelete", {
         group = group,
+        buffer = bufnr,
         callback = stop_continuous_testing_cmd(bufnr),
     })
 


### PR DESCRIPTION
This fixes an issue where simply opening and closing a quickfix list would stop the continuous testing.